### PR TITLE
Make transformer and constraints optional in FieldBuilder and FieldDe…

### DIFF
--- a/src/Builder/FieldBuilder.php
+++ b/src/Builder/FieldBuilder.php
@@ -7,9 +7,9 @@ use Netmex\HydratorBundle\Contracts\TransformerInterface;
 
 class FieldBuilder implements BuilderInterface
 {
-    private array $fields;
+    private array $fields = [];
 
-    public function add(string $field, TransformerInterface|string $type, ?array $constraints): static
+    public function add(string $field, TransformerInterface|string|null $type = null, ?array $constraints = []): static
     {
         $this->fields[$field] = [
             'Transformer' => $type,

--- a/src/Contracts/BuilderInterface.php
+++ b/src/Contracts/BuilderInterface.php
@@ -3,7 +3,7 @@
 namespace Netmex\HydratorBundle\Contracts;
 
 interface BuilderInterface {
-    public function add(string $field, TransformerInterface|string $type, ?array $constraints): static;
+    public function add(string $field, TransformerInterface|string|null $type = null, ?array $constraints = []): static;
 
     public function getFields(): array;
 }

--- a/src/Factory/MapperFactory.php
+++ b/src/Factory/MapperFactory.php
@@ -30,7 +30,7 @@ class MapperFactory
         foreach ($resolved['fields'] as $name => $fieldInfo) {
             $fields[] = new FieldDefinition(
                 name: $name,
-                transformer: new $fieldInfo['Transformer'],
+                transformer: isset($fieldInfo['Transformer']) ? new $fieldInfo['Transformer'] : null,
                 value: $data[$name] ?? null,
                 constraints: $fieldInfo['constraints'] ?? [],
             );

--- a/src/Mapper/FieldDefinition.php
+++ b/src/Mapper/FieldDefinition.php
@@ -7,7 +7,7 @@ class FieldDefinition
 {
     public function __construct(
         public string $name,
-        public TransformerInterface $transformer,
+        public ?TransformerInterface $transformer = null,
         public mixed $value = null,
         public array $constraints = []
     ) {}
@@ -17,7 +17,7 @@ class FieldDefinition
         return $this->name;
     }
 
-    public function getTransformer(): TransformerInterface
+    public function getTransformer(): ?TransformerInterface
     {
         return $this->transformer;
     }
@@ -39,11 +39,15 @@ class FieldDefinition
 
     public function transform(): void
     {
+        if ($this->transformer === null) {
+            return;
+        }
+
         $this->value = $this->transformer->transform($this->getValue());
     }
 
     public function isRequired(): bool
     {
-        return $this->constraints['required'];
+        return $this->constraints['required'] ?? false;
     }
 }

--- a/tests/Builder/FieldBuilderTest.php
+++ b/tests/Builder/FieldBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Netmex\HydratorBundle\Test\Builder;
+namespace Netmex\HydratorBundle\Tests\Builder;
 
 use Netmex\HydratorBundle\Builder\FieldBuilder;
 use Netmex\HydratorBundle\Contracts\TransformerInterface;
@@ -34,15 +34,29 @@ class FieldBuilderTest extends TestCase
 
     public function testAddAcceptsStringTransformer(): void
     {
-        $this->builder->add('status', 'string_transformer', null);
+        // When passing a string transformer and omitting constraints, constraints should default to an empty array
+        $this->builder->add('status', 'string_transformer');
 
         $expected = [
             'status' => [
                 'Transformer' => 'string_transformer',
-                'constraints' => null,
+                'constraints' => [],
             ],
         ];
 
         $this->assertEquals($expected, $this->builder->getFields());
+    }
+
+    public function testAddWithoutTransformerDefaultsConstraintsEmpty(): void
+    {
+        // Transformer is optional and constraints default to empty array
+        $this->builder->add('name');
+
+        $fields = $this->builder->getFields();
+
+        $this->assertArrayHasKey('name', $fields);
+        $this->assertArrayHasKey('Transformer', $fields['name']);
+        $this->assertNull($fields['name']['Transformer']);
+        $this->assertSame([], $fields['name']['constraints']);
     }
 }


### PR DESCRIPTION
…finition

- Update BuilderInterface and FieldBuilder to allow omitting transformer and constraints in add()
- Default constraints to empty array and transformer to null when not provided
- Adjust FieldDefinition to accept nullable transformer and default constraints
- Update MapperFactory to handle missing transformer
- Add tests for optional transformer and constraints in FieldBuilder